### PR TITLE
Handle failing script

### DIFF
--- a/bin/run-scripts
+++ b/bin/run-scripts
@@ -25,7 +25,12 @@ async.series(commands.map(function (command) {
 				console.log('exec error: ' + error);
 			}
 
-			callback();
+			callback(error);
 		});
 	};
-}));
+}), function (error) {
+	if (typeof error === 'undefined' || typeof error.code === 'undefined') {
+		return;
+	}
+	process.exit(error.code);
+});

--- a/package.json
+++ b/package.json
@@ -29,8 +29,11 @@
   "scripts": {
     "lint": "./node_modules/.bin/jshint *.js test/*.js bin/*",
     "mocha": "./node_modules/.bin/mocha test/*.js",
-    "test-script1": "echo 1",
-    "test-script2": "echo 2",
-    "test": "npm run lint && npm run mocha && ./bin/run-scripts test-script1 test-script2"
+    "script:success-one": "echo 'Success one'",
+    "script:success-two": "echo 'Success two'",
+    "script:failure": "echo 'Failure' && exit 1",
+    "test": "npm run lint && npm run mocha && npm run test:success && npm run test:failure",
+    "test:success": "./bin/run-scripts script:success-one script:success-two",
+    "test:failure": "! ./bin/run-scripts script:success-one script:failure"
   }
 }


### PR DESCRIPTION
Previously when a failure happened in one of the scripts being run it would simply ignore the error.
- Ignoring the error: https://travis-ci.org/renan/run-scripts/builds/84330601
- Handling the error: https://travis-ci.org/renan/run-scripts/builds/84332470
